### PR TITLE
Use QA_BASE_URL env var for tests

### DIFF
--- a/qa/run_all.sh
+++ b/qa/run_all.sh
@@ -79,5 +79,5 @@ PY
 
 echo "[6/6] Running tests..."
 cd "${ROOT_DIR}"
-pytest -q qa/ui
+QA_BASE_URL="${BASE_URL}" pytest -q qa/ui
 echo "PASS"

--- a/qa/ui/test_smoke_home.py
+++ b/qa/ui/test_smoke_home.py
@@ -1,8 +1,8 @@
 import os
 import requests
 
-def test_homepage_responds():
-    base_url = os.getenv("QA_BASE_URL", "http://127.0.0.1:8080")
-    r = requests.get(base_url + "/", timeout=5)
-    assert r.status_code < 500
+BASE_URL = os.getenv("QA_BASE_URL", "http://127.0.0.1:8080")
 
+def test_homepage():
+    r = requests.get(BASE_URL + "/", timeout=5)
+    assert r.status_code == 200


### PR DESCRIPTION
Completed issue. QA tests are now able to use the environment variable for the base URL. This will allow tests to be more dynamic instead of being hardcoded.