### PR TITLE
Add smoke test for Help page

### DIFF
--- a/qa/ui/test_help_page.py
+++ b/qa/ui/test_help_page.py
@@ -1,0 +1,8 @@
+import requests
+
+BASE_URL = "http://127.0.0.1:8080"
+
+def test_help_page_loads():
+    response = requests.get(BASE_URL + "/help/")
+    assert response.status_code == 200
+    assert "Help" in response.text


### PR DESCRIPTION
Adds a simple QA smoke test for the Help page.

- Sends GET request to /help/
- Asserts status code 200
- Verifies page contains "Help"

Test runs via ./qa/run_all.sh