### PR TITLE
Fixed Sign in button #87

### DIFF
--- a/cccSite/account/templates/account/signin.html
+++ b/cccSite/account/templates/account/signin.html
@@ -101,7 +101,7 @@
     $("#signin-modal").on("click", "#signin", function (e) {
 
         $.ajax({
-            url: "/contribute/signin/",
+            url: "{% url 'account:signin' %}",
             type: "POST",
             data: {
                 username: $(signin_username).val(),


### PR DESCRIPTION
## Issue
https://github.com/drsimonread/ChesapeakeCommunityConnect/issues/87
The Sign in button didn't do anything when pressed
### Solution
Had to change the location of the button action from hard-coded to something more dynamic using Django template.