### PR TITLE
Fix accordion behavior (single open tab + stop video)

### DIFF
--- a/cccSite/boiler/templates/boiler/help.html
+++ b/cccSite/boiler/templates/boiler/help.html
@@ -82,14 +82,34 @@
 
 <script>
   var acc = document.getElementsByClassName("accordion");
+
   for (var i = 0; i < acc.length; i++) {
     acc[i].addEventListener("click", function () {
-      this.classList.toggle("active");
+
       var panel = this.nextElementSibling;
-      if (panel.style.maxHeight) {
-        panel.style.maxHeight = null;
-      } else {
+      var isOpen = panel.style.maxHeight;
+
+      // 🔴 CLOSE ALL OTHER PANELS FIRST
+      for (var j = 0; j < acc.length; j++) {
+        var otherPanel = acc[j].nextElementSibling;
+
+        acc[j].classList.remove("active");
+        otherPanel.style.maxHeight = null;
+
+        // 🔥 Stop video if it's inside
+        var video = otherPanel.querySelector("video");
+        if (video) {
+          video.pause();
+          video.currentTime = 0;
+        }
+      }
+
+      // 🟢 OPEN CURRENT ONE (only if it was closed)
+      if (!isOpen) {
+        this.classList.add("active");
         panel.style.maxHeight = panel.scrollHeight + "px";
+
+        // keep your tutorial height fix
         if (panel.classList.contains("panel--tutorial")) {
           var fixTutorialHeight = function () {
             panel.style.maxHeight = panel.scrollHeight + "px";


### PR DESCRIPTION
### Summary

This pull request resolves issue #188 by improving the behavior of the FAQ accordion on the Help page.

### Changes Made

* Updated accordion JavaScript logic so that only one section can be open at a time
* Automatically closes previously opened sections when a new one is clicked
* Added logic to pause and reset the tutorial video when its section is closed

### Result

* Cleaner and more intuitive user experience
* Prevents multiple sections from being open simultaneously
* Eliminates background video playback when switching tabs

### Testing

* Opened multiple accordion sections to confirm only one remains open
* Verified that the tutorial video pauses and resets when switching sections

### Related Issue

Closes #188
<img width="946" height="497" alt="Screenshot 2026-04-27 161012" src="https://github.com/user-attachments/assets/afbaf7f6-68a1-442e-83df-63c5994d2057" />
<img width="947" height="492" alt="Screenshot 2026-04-27 161047" src="https://github.com/user-attachments/assets/df286385-c5b2-4b3e-b134-a5d197f08537" />
<img width="951" height="525" alt="Screenshot 2026-04-27 161325" src="https://github.com/user-attachments/assets/a9581569-d374-4d55-8a21-012d788db913" />
